### PR TITLE
Pin markdownify version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
     - run: |-
         pip install \
          feedparser \
-         markdownify \
+         markdownify==0.12.1 \
          git+https://github.com/i-ky/python-zulip-api.git@markdownify#subdirectory=zulip
         $HOME/.local/share/zulip/integrations/rss/rss-bot \
          --markdownify \


### PR DESCRIPTION
This fixes https://osmlatvija.github.io/zulip-archive/stream/362235-Zulip/topic/par.20daudz.20backslashu.html which was caused by https://github.com/matthewwithanm/python-markdownify/pull/118.

Note that there are improvements coming up - https://github.com/matthewwithanm/python-markdownify/pull/122, so "sit and wait" may also be a good solution strategy.