### PR TITLE
Add more reasonable batch size for our usecase

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,6 +19,7 @@ jobs:
          --api-key '${{ secrets.zulip_bot_key }}' \
          --user '${{ secrets.zulip_bot_email }}' \
          --feed-file rss-feeds \
+         --max-batch-size 100 \
          --data-dir data/ \
          --stream RSS
         git config --global user.email "zulip-rss-bot@users.noreply.github.com"


### PR DESCRIPTION
Recent changes introduced to rss-bot set default batch size to three items.
This is way to low for our use case of running bot only four times a day, since notes can be created at a significantly faster rate.
Discussion of the issue at [#general > Changesets requesting review @ 💬](https://osmlatvija.zulipchat.com/#narrow/channel/358602-general/topic/Changesets.20requesting.20review/near/579674765)